### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/snmp/AbstractSnmpTask.java
+++ b/src/main/java/io/kestra/plugin/snmp/AbstractSnmpTask.java
@@ -46,7 +46,8 @@ public abstract class AbstractSnmpTask extends Task {
     protected Property<String> snmpVersion = Property.ofValue("v2c");
 
     @Schema(title = "Community string (v1/v2c)", description = "Plaintext community for v1/v2c; ignored for v3")
-    @PluginProperty(group = "advanced")
+    @PluginProperty(secret = true, group = "advanced")
+    @ToString.Exclude
     protected Property<String> community;
 
     @Schema(title = "SNMPv3 security settings", description = "Username and optional auth/privacy protocols required for v3")
@@ -80,7 +81,19 @@ public abstract class AbstractSnmpTask extends Task {
     @Getter
     @AllArgsConstructor
     public enum AuthProtocol {
+        /**
+         * @deprecated MD5 is cryptographically broken (CWE-327) and should not be used for new
+         * configurations. Retained only for compatibility with legacy devices that support no
+         * stronger algorithm. Prefer SHA256 or higher.
+         */
+        @Deprecated
         MD5(AuthMD5.ID),
+        /**
+         * @deprecated SHA-1 is considered weak (CWE-327) and should not be used for new
+         * configurations. Retained only for compatibility with legacy devices that support no
+         * stronger algorithm. Prefer SHA256 or higher.
+         */
+        @Deprecated
         SHA(AuthSHA.ID),
         SHA224(AuthHMAC128SHA224.ID),
         SHA256(AuthHMAC192SHA256.ID),
@@ -98,11 +111,28 @@ public abstract class AbstractSnmpTask extends Task {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unsupported auth protocol: " + name));
         }
+
+        public static AuthProtocol fromStringEnum(String name) {
+            return Arrays.stream(values())
+                .filter(p -> p.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported auth protocol: " + name));
+        }
+
+        public boolean isWeak() {
+            return this == MD5 || this == SHA;
+        }
     }
 
     @Getter
     @AllArgsConstructor
     public enum PrivProtocol {
+        /**
+         * @deprecated DES is cryptographically broken (CWE-327, 56-bit key) and should not be used
+         * for new configurations. Retained only for compatibility with legacy devices that support
+         * no stronger algorithm. Prefer AES128 or higher.
+         */
+        @Deprecated
         DES(PrivDES.ID),
         AES128(PrivAES128.ID),
         AES192(PrivAES192.ID),
@@ -118,6 +148,17 @@ public abstract class AbstractSnmpTask extends Task {
                 .map(PrivProtocol::getOid)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unsupported privacy protocol: " + name));
+        }
+
+        public static PrivProtocol fromStringEnum(String name) {
+            return Arrays.stream(values())
+                .filter(p -> p.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported privacy protocol: " + name));
+        }
+
+        public boolean isWeak() {
+            return this == DES;
         }
     }
 
@@ -147,7 +188,7 @@ public abstract class AbstractSnmpTask extends Task {
         @PluginProperty(secret = true, group = "connection")
         private String username;
 
-        @Schema(title = "Auth protocol", description = "MD5, SHA, SHA224, SHA256, SHA384, SHA512; blank disables authentication")
+        @Schema(title = "Auth protocol", description = "MD5, SHA, SHA224, SHA256, SHA384, SHA512; blank disables authentication. MD5 and SHA (SHA-1) are cryptographically weak and deprecated; prefer SHA256 or higher.")
         @PluginProperty(group = "connection")
         private String authProtocol;
 
@@ -155,7 +196,7 @@ public abstract class AbstractSnmpTask extends Task {
         @PluginProperty(secret = true, group = "connection")
         private String authPassword;
 
-        @Schema(title = "Privacy protocol", description = "DES, AES128, AES192, AES256; blank disables encryption")
+        @Schema(title = "Privacy protocol", description = "DES, AES128, AES192, AES256; blank disables encryption. DES is cryptographically weak and deprecated; prefer AES128 or higher.")
         @PluginProperty(group = "advanced")
         private String privProtocol;
 

--- a/src/main/java/io/kestra/plugin/snmp/SnmpVersion.java
+++ b/src/main/java/io/kestra/plugin/snmp/SnmpVersion.java
@@ -83,6 +83,15 @@ public enum SnmpVersion {
             OID authProt = AbstractSnmpTask.AuthProtocol.fromString(sec.getAuthProtocol());
             OID privProt = AbstractSnmpTask.PrivProtocol.fromString(sec.getPrivProtocol());
 
+            if (sec.getAuthProtocol() != null && !sec.getAuthProtocol().isBlank()
+                && AbstractSnmpTask.AuthProtocol.fromStringEnum(sec.getAuthProtocol()).isWeak()) {
+                runContext.logger().warn("SNMPv3 auth protocol '{}' is cryptographically weak and deprecated; prefer SHA256 or higher.", sec.getAuthProtocol());
+            }
+            if (sec.getPrivProtocol() != null && !sec.getPrivProtocol().isBlank()
+                && AbstractSnmpTask.PrivProtocol.fromStringEnum(sec.getPrivProtocol()).isWeak()) {
+                runContext.logger().warn("SNMPv3 privacy protocol '{}' is cryptographically weak and deprecated; prefer AES128 or higher.", sec.getPrivProtocol());
+            }
+
             snmp.getUSM().addUser(
                 new OctetString(sec.getUsername()),
                 new UsmUser(


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — community field missing `@PluginProperty(secret=true)` — `src/main/java/io/kestra/plugin/snmp/AbstractSnmpTask.java:50` — Added `secret = true` to the `community` field's `@PluginProperty` annotation so the SNMP v1/v2c community string (a plaintext credential) is no longer exposed in the UI, API, logs, or flow exports.
- **MEDIUM** — community credential included in `@ToString` output with no exclusion — `src/main/java/io/kestra/plugin/snmp/SendTrap.java:20` — Added `@ToString.Exclude` to the `community` field declaration in `AbstractSnmpTask.java` so it is never rendered by generated `toString()` implementations on `SendTrap`/`SendInform`.
- **MEDIUM** — weak authentication and encryption algorithms exposed as selectable options (MD5, SHA-1, DES) — `src/main/java/io/kestra/plugin/snmp/AbstractSnmpTask.java:83` — Marked `MD5`/`SHA` (auth) and `DES` (privacy) enum constants as `@Deprecated` with Javadoc guidance, updated the `@Schema` descriptions on `authProtocol`/`privProtocol` to warn users, and added a runtime warning log (`SnmpVersion.java`) when a weak algorithm is selected for SNMPv3. Values are retained (not removed) to avoid breaking compatibility with legacy devices that only support these algorithms.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-snmp/issues/52
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
